### PR TITLE
fixed error on point.update()

### DIFF
--- a/js/indicators.js
+++ b/js/indicators.js
@@ -191,7 +191,7 @@
 		*  Force redraw for indicator with new point options, like value
 		*/
 		HC.wrap(HC.Point.prototype, 'update', function(proceed, options, redraw) {
-				forceRedraw(this);
+				forceRedraw(this.series);
 				proceed.call(this, options, redraw);
 		});
 		


### PR DESCRIPTION
Calling update() on a Point object ended up calling forceRedraw on the Point and not the Series, which caused an error. This should fix it.