### PR TITLE
Check if legend is enabled in Indicator's setVisible method. Issue #43

### DIFF
--- a/js/indicators.js
+++ b/js/indicators.js
@@ -863,8 +863,10 @@
 		setVisible: function (vis) {
 			var indicator = this,
 				oldVis = indicator.visible,
+				legend = indicator.chart.legend,
 				newVis,
 				method;
+
 			
 			if (vis === UNDEFINED) {
 				newVis = oldVis ? false : true;
@@ -874,8 +876,8 @@
 				method = vis ? 'show' : 'hide';
 			}
 			
-			if (this.options.showInLegend) {
-				this.chart.legend.colorizeItem(this, newVis);
+			if (legend.options.enabled && this.options.showInLegend) {
+				legend.colorizeItem(this, newVis);
 			}
 			this.visible = newVis;
 			


### PR DESCRIPTION
If a chart has disabled legend and indicator's showInLegend enabled setVisibility method fails - tries to call colorizeItem on undefined.