### PR TITLE
ATR/RSI cannot display if series.type is 'line'

### DIFF
--- a/js/indicators.js
+++ b/js/indicators.js
@@ -79,6 +79,20 @@
 			followPointer: true
 		}
 	});
+	
+	// Pass correct series.yData to getValues() before render()
+	function properYData(series) {
+		if (HC.isArray(series.yData) && (series.yData.length >0) && HC.isArray(series.yData[0]) && (series.yData[0].length === 4)) {
+			return series.yData;
+		}
+		else {
+			var arr = [];
+			series.options.data.forEach(function(value) {
+				arr.push([value[0], value[1], value[2], value[3]])
+			});
+			return arr;
+		}
+	}
 
 	
 	/**
@@ -519,7 +533,7 @@
 				error('Series not found');
 				return;
 			} else if (!graph) {
-				arrayValues = Indicator.prototype[options.type].getValues(chart, { points: [] }, options, [series.xData, series.yData]);
+				arrayValues = Indicator.prototype[options.type].getValues(chart, { points: [] }, options, [series.xData, properYData(series)]);
 				if (!arrayValues) { // #6 - create dummy data
 					arrayValues = {
 						values: [[]],

--- a/js/indicators.js
+++ b/js/indicators.js
@@ -81,16 +81,21 @@
 	});
 	
 	// Pass correct series.yData to getValues() before render()
-	function properYData(series) {
-		if (HC.isArray(series.yData) && (series.yData.length >0) && HC.isArray(series.yData[0]) && (series.yData[0].length === 4)) {
-			return series.yData;
+	function properYData(series, type) {
+		if (type === 'rsi' || type === 'atr') {
+			if (HC.isArray(series.yData) && (series.yData.length >0) && HC.isArray(series.yData[0]) && (series.yData[0].length === 4)) {
+				return series.yData;
+			}
+			else {
+				var arr = [];
+				series.options.data.forEach(function(value) {
+					arr.push([value[0], value[1], value[2], value[3]])
+				});
+				return arr;
+			}
 		}
 		else {
-			var arr = [];
-			series.options.data.forEach(function(value) {
-				arr.push([value[0], value[1], value[2], value[3]])
-			});
-			return arr;
+			return series.yData;
 		}
 	}
 
@@ -533,7 +538,7 @@
 				error('Series not found');
 				return;
 			} else if (!graph) {
-				arrayValues = Indicator.prototype[options.type].getValues(chart, { points: [] }, options, [series.xData, properYData(series)]);
+				arrayValues = Indicator.prototype[options.type].getValues(chart, { points: [] }, options, [series.xData, properYData(series, indicator.name)]);
 				if (!arrayValues) { // #6 - create dummy data
 					arrayValues = {
 						values: [[]],


### PR DESCRIPTION
ATR/RSI cannot display if series.type is 'line / kagi / spline / area / area range / area spline range'. 

For example, In the line 72 in the demo :  http://jsfiddle.net/RE7sS/205/, the code below:
adv_options.series[0].type = 'candlestick';
When change the value 'candlestick' to 'line' in the code above, the two button ('RSI' and 'ATR') in the result page will not work.

In normal conditions every element in the array 'series.yData' should be another array with 4 values. But in these cases above ( e.g. when the type of series is line ) the elements in the array 'series.yData' are just plain numbers ( see official API : series.data doesn't contain all the points. It only contains the points that have been created on demand......Additionally, 'series.options.data' contains all configuration objects for the points ). 

So additional function 'properYData(series)' is added utilizing the variable 'series.options.data' to deal with this problem and return the correct yData array.
